### PR TITLE
Fix assets lookup for precompiled assets

### DIFF
--- a/test/unit/wicked_pdf_test.rb
+++ b/test/unit/wicked_pdf_test.rb
@@ -1,5 +1,5 @@
 require 'test_helper'
-WickedPdf.config = { :exe_path => ENV['WKHTMLTOPDF_BIN'] || '/usr/local/bin/wkhtmltopdf' }
+WickedPdf.config = { :exe_path => ENV['WKHTMLTOPDF_BIN'] }
 HTML_DOCUMENT = '<html><body>Hello World</body></html>'.freeze
 
 # Provide a public accessor to the normally-private parse_options function.

--- a/wicked_pdf.gemspec
+++ b/wicked_pdf.gemspec
@@ -35,4 +35,6 @@ DESC
   spec.add_development_dependency 'sqlite3', '~> 1.3.6'
   spec.add_development_dependency 'mocha', '= 1.3'
   spec.add_development_dependency 'test-unit'
+  spec.add_development_dependency 'bootsnap'
+  spec.add_development_dependency 'rdoc'
 end


### PR DESCRIPTION
  - use asset_manifest if available
  - gems missing from dev dependencies
  - remove static preset asset path in unit test that breaks tests for anyone without ENV variable set